### PR TITLE
Fix: Remove focus outline from notebook tabs

### DIFF
--- a/EDAPGui.py
+++ b/EDAPGui.py
@@ -1486,6 +1486,12 @@ def main():
     app = APGui(root)
 
     sv_ttk.set_theme("dark")
+
+    # Remove focus outline from tabs by setting focuscolor to the background color
+    style = ttk.Style()
+    bg_color = "#1c1c1c" if sv_ttk.get_theme() == "dark" else "#fafafa"
+    style.configure("TNotebook.Tab", focuscolor=bg_color)
+
     if sys.platform == "win32":
         apply_theme_to_titlebar(root)
     root.mainloop()


### PR DESCRIPTION
Sets the `focuscolor` of the `TNotebook.Tab` style to the theme's background color. This makes the focus outline invisible, resolving the issue of a dotted border appearing on double-click.