### PR TITLE
=This commit addresses two issues related to saving waypoint files.

### DIFF
--- a/EDAPWaypointEditor.py
+++ b/EDAPWaypointEditor.py
@@ -396,8 +396,36 @@ class WaypointEditorTab:
             messagebox.showerror("Error", f"Failed to load waypoint file: {e}")
 
     def save_waypoint_file(self, filepath):
-        raw_waypoints = self.convert_to_raw_waypoints()
-        self.ed_waypoint.write_waypoints(raw_waypoints, filepath)
+        waypoints_to_save = {}
+
+        # Add or preserve GlobalShoppingList at the top
+        if 'GlobalShoppingList' in self.ed_waypoint.waypoints:
+            waypoints_to_save['GlobalShoppingList'] = self.ed_waypoint.waypoints['GlobalShoppingList']
+        else:
+            # Add default GlobalShoppingList for new files
+            waypoints_to_save['GlobalShoppingList'] = {
+                "SystemName": "",
+                "StationName": "",
+                "GalaxyBookmarkType": "",
+                "GalaxyBookmarkNumber": 0,
+                "SystemBookmarkType": "",
+                "SystemBookmarkNumber": 0,
+                "SellCommodities": {},
+                "BuyCommodities": {},
+                "Comment": None,
+                "UpdateCommodityCount": True,
+                "FleetCarrierTransfer": False,
+                "Skip": True,
+                "Completed": False
+            }
+
+        # Add the rest of the waypoints
+        other_waypoints = self.convert_to_raw_waypoints()
+        if 'GlobalShoppingList' in other_waypoints:
+            del other_waypoints['GlobalShoppingList']
+        waypoints_to_save.update(other_waypoints)
+
+        self.ed_waypoint.write_waypoints(waypoints_to_save, filepath)
         self.ed_waypoint.filename = filepath
         self.mesg_client.publish(LoadWaypointFileAction(filepath=filepath))
 


### PR DESCRIPTION
First, when saving a new waypoint file from the editor, the `GlobalShoppingList` was not being added. This caused an error when trying to load the file later, as the application expects this section to exist. The `save_waypoint_file` method in `EDAPWaypointEditor.py` is modified to ensure a `GlobalShoppingList` is always present. It is preserved from the original file if it exists, otherwise a default is created. The implementation ensures it is the first entry in the JSON file.

Second, based on user feedback, the default `GlobalShoppingList` no longer contains pre-filled commodities. The `BuyCommodities` dictionary is now empty by default.

A defensive check has been added to prevent a user-created waypoint named "GlobalShoppingList" from overwriting the main entry.