### PR TITLE
Fix: Prevent crash after interdiction in supercruise assist

### DIFF
--- a/ED_AP.py
+++ b/ED_AP.py
@@ -2146,6 +2146,7 @@ class EDAutopilot:
             if interdicted:
                 # Continue journey after interdiction
                 self.keys.send('SetSpeed50')
+                self.status.wait_for_flag_on(FlagsSupercruise, timeout=30)  # Wait to get back into supercruise
                 self.nav_align(scr_reg)  # realign with station
 
             # check for SC Disengage


### PR DESCRIPTION
When being interdicted during supercruise assist, the script would attempt to realign with the destination by calling `nav_align` immediately after the interdiction sequence.

However, the ship might not have fully re-entered supercruise at that point, causing the `nav_align` function to raise an exception because the ship's status was not 'in_supercruise' or 'in_space'.

This change adds a wait for the `FlagsSupercruise` flag to be set after an interdiction. This ensures the ship is in the correct state before `nav_align` is called, preventing the crash.