### PR TITLE
Fix wing mining mission turn-in

### DIFF
--- a/EDStationServicesInShip.py
+++ b/EDStationServicesInShip.py
@@ -812,7 +812,8 @@ class EDStationServicesInShip:
                                     mission_accepted_event = self.ap.jn.wait_for_event('MissionAccepted')
                                     if mission_accepted_event:
                                         mission_id = mission_accepted_event.get('MissionID')
-                                        accepted_missions.append({"commodity": matched_commodity, "tonnage": tonnage, "reward": reward, "mission_id": mission_id, "ocr_text": details_text})
+                                        ocr_text = match.group(0)
+                                        accepted_missions.append({"commodity": matched_commodity, "tonnage": tonnage, "reward": reward, "mission_id": mission_id, "ocr_text": ocr_text})
                                     else:
                                         logger.warning("Did not find MissionAccepted event in journal")
                                     sleep(5)

--- a/WingMining.py
+++ b/WingMining.py
@@ -349,7 +349,7 @@ class WingMining:
 
             if ocr_textlist:
                 current_text = " ".join(ocr_textlist)
-                if current_text.startswith(ocr_text_to_find):
+                if current_text.upper().startswith(ocr_text_to_find.upper()):
                     item_found = True
                     break
 


### PR DESCRIPTION
The OCR text for wing mining missions included the reward and other details, which caused the mission turn-in to fail as the on-screen text did not contain this extra information.

This change modifies the mission scanning to store only the matched mission description as the OCR text, excluding the extra details.

Additionally, the mission lookup during turn-in is now case-insensitive to make it more robust.