### PR TITLE
Fix: Ensure correct mission turn-in after partial buys

### DIFF
--- a/WingMining.py
+++ b/WingMining.py
@@ -36,6 +36,7 @@ class WingMining:
         self.failed_carriers = []
         self.current_carrier_name = None
         self.mission_scanner_mode = False
+        self.current_mission_original_tonnage = None
         self._load_state()
 
     def _get_state(self):
@@ -45,6 +46,7 @@ class WingMining:
             "current_mission": self.current_mission,
             "current_station_idx": self.current_station_idx,
             "mission_turned_in": self.mission_turned_in,
+            "current_mission_original_tonnage": self.current_mission_original_tonnage,
         }
 
     def _load_state(self):
@@ -55,6 +57,9 @@ class WingMining:
             self.current_mission = state.get("current_mission", None)
             self.current_station_idx = state.get("current_station_idx", 0)
             self.mission_turned_in = state.get("mission_turned_in", False)
+            self.current_mission_original_tonnage = state.get("current_mission_original_tonnage", None)
+            if self.current_mission and self.current_mission_original_tonnage is None:
+                self.current_mission_original_tonnage = self.current_mission['tonnage']
             logger.info("Wing Mining state restored.")
 
     def start(self):
@@ -226,6 +231,7 @@ class WingMining:
     def _handle_process_queue(self):
         if self.mission_queue:
             self.current_mission = self.mission_queue.pop(0)
+            self.current_mission_original_tonnage = self.current_mission['tonnage']
             self.failed_carriers = [] # Reset blacklist for new mission
             self.set_state(STATE_TRAVEL_TO_FC)
         else:
@@ -437,7 +443,7 @@ class WingMining:
         # We need to match the mission based on its core attributes, not the full OCR text
         # which might include variable reward amounts.
         target_commodity = mission['commodity']
-        target_tonnage = mission['tonnage']
+        target_tonnage = self.current_mission_original_tonnage
 
         mission_name_patterns = [
             "Mine",


### PR DESCRIPTION
The wing mining assistant was failing to turn in missions correctly after purchasing the required commodities in partial amounts. This was because the `tonnage` value in the `current_mission` dictionary was being modified during the acquisition process, leading to an incorrect value being used when searching for the mission on the mission board.

This commit fixes the issue by introducing a new state variable, `current_mission_original_tonnage`, to the `WingMining` class.

- This variable stores the mission's original tonnage when it is first processed.
- It is persisted in the state file, with migration logic to handle older state files.
- The mission turn-in logic now uses this immutable original tonnage value for lookups, ensuring the correct mission is always found.