### PR TITLE
feat: Add bottom buffer to pages

### DIFF
--- a/nicegui_ui/theme.py
+++ b/nicegui_ui/theme.py
@@ -16,7 +16,7 @@ def frame(navtitle: str, status_label: ui.label):
         with ui.column():
             menu()
 
-    with ui.column().classes('absolute-center items-center h-screen no-wrap p-9 w-full'):
+    with ui.column().classes('absolute-center items-center min-h-screen no-wrap p-9 pb-32 w-full'):
         yield
 
     with ui.footer(value=True) as footer:


### PR DESCRIPTION
Replaced h-screen with min-h-screen and added pb-32 to the main content column to prevent content from being cut off at the bottom of the page.